### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/doc/README_md.html
+++ b/doc/README_md.html
@@ -93,7 +93,7 @@
 <main role="main" aria-label="Page README.md">
 
 <p><a href="https://www.moviemasher.com"><img
-src="https://rawgit.com/moviemasher/moviemasher.rb/master/README/logo-120x60.png"></a>
+src="https://combinatronics.com/moviemasher/moviemasher.rb/master/README/logo-120x60.png"></a>
 <strong><a
 href="https://github.com/moviemasher/moviemasher.js">moviemasher.js</a> |
 <a
@@ -137,7 +137,7 @@ triggered when a job is started, during its processing and/or when it&#39;s
 completed.</p>
 <ul><li>
 <p><strong>Documentation:</strong> generated with RDoc from source <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/index.html">(HTML)</a></p>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/index.html">(HTML)</a></p>
 </li><li>
 <p><strong>Docker Image:</strong> <code>moviemasher/moviemasher.rb</code> <a
 href="Dockerfile">(Dockerfile)</a></p>
@@ -154,10 +154,10 @@ can be used to package these into job descriptions.</p>
 
 <p>Jobs are provided to the system for processing in different ways, depending
 on how it&#39;s been configured and deployed. At the lowest level, the <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process">MovieMasher.process</a>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process">MovieMasher.process</a>
 method is sent a job as a hash, a JSON/YAML formatted string or a local
 path to one. The <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
 method calls it with any jobs it finds while scanning a preconfigured watch
 folder or queue. This scanning can be done for a certain number of seconds,
 until no jobs are found, just once or forever. There are rake tasks for
@@ -296,22 +296,22 @@ recognize so that containers behave as expected. The following commands are
 supported:</p>
 <ul><li>
 <p>moviemasher (default): call <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a></p>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a></p>
 </li><li>
 <p>process_one: call <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
 with <strong>process_seconds</strong>=-1</p>
 </li><li>
 <p>process_all: call <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
 with <strong>process_seconds</strong>=-2</p>
 </li><li>
 <p>process_loop: call <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process_queues">MovieMasher.process_queues</a>
 with <strong>process_seconds</strong>=-3</p>
 </li><li>
 <p>process: call <a
-href="https://rawgit.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process">MovieMasher.process</a>
+href="https://combinatronics.com/moviemasher/moviemasher.rb/master/doc/MovieMasher.html#method-c-process">MovieMasher.process</a>
 for each supplied argument</p>
 </li></ul>
 


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.