### PR TITLE
update git repo for x264 at vlc foundry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN \
 # pull, configure, make and install x264
 RUN \
   cd /data; \
-  git clone git://git.videolan.org/x264.git; \
+  git clone https://code.videolan.org/videolan/x264.git; \
   cd /data/x264; \
   git checkout ba24899b0bf23345921da022f7a51e0c57dbe73d; \
   ./configure --prefix=/usr --enable-shared; \


### PR DESCRIPTION
Hi!
`git://git.videolan.org/x264.git` is now 404, it's https://code.videolan.org/videolan/x264.git

Thanks